### PR TITLE
Improve offline cache sync behavior

### DIFF
--- a/utils/offline_cache.py
+++ b/utils/offline_cache.py
@@ -1,41 +1,73 @@
 import json
 import os
-import supabase
 
-CACHE_FILE = "turnos_cache.json"
+# Archivo donde se almacenan las operaciones pendientes. La estructura es un
+# diccionario con el nombre de la tabla como clave y una lista de filas como
+# valor, e.g. {"turnos": [{...}, {...}], "clientes": [{...}]}
+CACHE_FILE = "cache_pendiente.json"
 
-def guardar_turno_local(turno):
-    """Guarda un turno en caché local si no hay conexión"""
-    turnos = []
+
+def guardar_turno_local(tabla: str, datos: dict) -> None:
+    """Guarda una fila para la tabla dada en la caché local."""
+    cache: dict[str, list] = {}
     if os.path.exists(CACHE_FILE):
-        with open(CACHE_FILE, "r") as f:
-            turnos = json.load(f)
-    turnos.append(turno)
-    with open(CACHE_FILE, "w") as f:
-        json.dump(turnos, f)
+        with open(CACHE_FILE, "r", encoding="utf-8") as f:
+            try:
+                cache = json.load(f)
+            except json.JSONDecodeError:
+                cache = {}
 
-def obtener_turnos_locales():
-    """Obtiene los turnos cacheados localmente"""
+    cache.setdefault(tabla, []).append(datos)
+
+    with open(CACHE_FILE, "w", encoding="utf-8") as f:
+        json.dump(cache, f)
+
+
+def obtener_cache() -> dict:
+    """Devuelve el contenido completo de la caché."""
     if not os.path.exists(CACHE_FILE):
-        return []
-    with open(CACHE_FILE, "r") as f:
-        return json.load(f)
+        return {}
+    with open(CACHE_FILE, "r", encoding="utf-8") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return {}
 
-def limpiar_cache():
+
+def obtener_turnos_locales() -> list:
+    """Obtiene únicamente los turnos almacenados en la caché."""
+    cache = obtener_cache()
+    return cache.get("turnos", [])
+
+
+def limpiar_cache() -> None:
     if os.path.exists(CACHE_FILE):
         os.remove(CACHE_FILE)
 
-def sincronizar_cache():
-    """Envía los turnos locales a Supabase si hay conexión"""
-    turnos = obtener_turnos_locales()
-    if not turnos:
+
+def sincronizar_cache() -> None:
+    """Envía los datos cacheados a Supabase si hay conexión."""
+    cache = obtener_cache()
+    if not cache:
         return
 
-    for turno in turnos:
-        try:
-            supabase.table("turnos").insert(turno).execute()
-        except Exception:
-            print("Error al sincronizar un turno")
-            return  # Abortamos si falla uno
+    # Importación diferida para evitar dependencias circulares
+    from config.supabase_client import supabase
 
-    limpiar_cache()
+    errores = False
+    for tabla, filas in cache.items():
+        for fila in filas:
+            try:
+                respuesta = supabase.table(tabla).insert(fila).execute()
+                if getattr(respuesta, "error", None):
+                    print(f"[SYNC ERROR] {respuesta.error}")
+                    errores = True
+            except Exception as e:  # pragma: no cover - log de sincronización
+                print(f"[SYNC ERROR] No se pudo insertar {fila}: {e}")
+                errores = True
+
+    if not errores:
+        limpiar_cache()
+        print("[SYNC] Caché sincronizada con Supabase")
+    else:
+        print("[SYNC] Algunos datos no se pudieron sincronizar")

--- a/utils/sync.py
+++ b/utils/sync.py
@@ -1,5 +1,5 @@
 from config.supabase_client import supabase
-from offline_cache import obtener_cache, limpiar_cache
+from .offline_cache import obtener_cache, limpiar_cache
 
 def sincronizar_cache():
     cache = obtener_cache()


### PR DESCRIPTION
## Summary
- Generalize local cache to handle multiple tables and synchronize through Supabase client
- Fix sync module imports to use new cache helpers

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile utils/offline_cache.py utils/sync.py config/supabase_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7a06a8704832297ebd52883be652f